### PR TITLE
Fix require script caching

### DIFF
--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -38,7 +38,7 @@ class ConfigManager
             $this->configFilePath = $configFilePath;
 
             if (file_exists($configFilePath)) {
-                $this->configData = require $configFilePath;
+                $this->configData = eval(str_replace(array('<?php', '?>'), '', file_get_contents($configFilePath)));
             }
         }
 


### PR DESCRIPTION
Suppose we are in save controller php script that saves some data to config file, and suppose that script 302-redirects to get method of that controller which retrieve written to that config-file data.
In that case php may cache require'd file and you get old data. To fix that, don't require config file, you may, for example, file_get_content's it and than eval returned string with config file.

See Issue #2