### PR TITLE
Interface definition and general improvements

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+    - uses: nanasess/setup-php@master
+        with:
+          php-version: '7.4'
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,11 +8,19 @@ on:
 
 jobs:
   build:
+    name: Prepare
+    runs-on: ${{ matrix.operating-system }}
+      strategy:
+        matrix:
+          operating-system: [ ubuntu-18.04, windows-2019 ]
+          php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4' ]
+      name: PHP ${{ matrix.php }}
+
     steps:
     - uses: actions/checkout@v2
     - uses: nanasess/setup-php@master
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php }}
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-18.04, windows-2019 ]
+        operating-system: [ ubuntu-18.04 ]
         php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4' ]
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,19 +8,18 @@ on:
 
 jobs:
   build:
-    name: Prepare
     runs-on: ${{ matrix.operating-system }}
-      strategy:
-        matrix:
-          operating-system: [ ubuntu-18.04, windows-2019 ]
-          php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4' ]
-      name: PHP ${{ matrix.php }}
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-18.04, windows-2019 ]
+        php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4' ]
+    name: PHP ${{ matrix.php }}
 
     steps:
     - uses: actions/checkout@v2
     - uses: nanasess/setup-php@master
-        with:
-          php-version: ${{ matrix.php }}
+      with:
+        php-version: ${{ matrix.php }}
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-18.04 ]
         php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4' ]
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.operating-system }} ${{ matrix.php }}
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,14 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit --no-coverage",
-        "coverage": "./vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "./vendor/bin/phpunit --no-coverage"
+        ],
+        "coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -dzend_extension=xdebug.so ./vendor/bin/phpunit"
+        ],
+        "debug": "php -dxdebug.remote_autostart=On -dzend_extension=xdebug.so ./vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,10 @@
             "php -dzend_extension=xdebug.so ./vendor/bin/phpunit"
         ],
         "debug": "php -dxdebug.remote_autostart=On -dzend_extension=xdebug.so ./vendor/bin/phpunit"
+    },
+    "config": {
+        "platform": {
+            "php": "5.4"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4891effe3d8ee390aa06d5a8dd37fb9c",
+    "content-hash": "6d2aba6439fb7be37e7120eed3311f56",
     "packages": [],
     "packages-dev": [
         {
@@ -39,34 +39,32 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.3,<8.0-DEV"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -86,99 +84,46 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "homepage": "https://github.com/doctrine/instantiator",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
+                "psr-0": {
+                    "phpDocumentor": [
                         "src/"
                     ]
                 }
@@ -190,88 +135,40 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -304,7 +201,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1057,16 +954,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
@@ -1078,7 +975,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1111,39 +1012,44 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.31",
+            "version": "v2.8.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3dc414b7db30695bae671a1d86013d03f4ae9834"
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3dc414b7db30695bae671a1d86013d03f4ae9834",
-                "reference": "3dc414b7db30695bae671a1d86013d03f4ae9834",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=5.3.9",
                 "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1170,57 +1076,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-20T13:31:17+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2018-11-11T11:18:13+00:00"
         }
     ],
     "aliases": [],
@@ -1231,5 +1087,9 @@
     "platform": {
         "php": ">=5.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.4"
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,4 +16,12 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <logging>
+        <log type="coverage-html" target="build/coverage/"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
+        <log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" />
+    </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,12 +10,24 @@
          stopOnFailure="false"
          verbose="true"
          printerClass="clagiordano\PhpunitResultPrinter\ResultPrinter"
-        >
+>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <ini name="display_errors" value="On"/>
+        <ini name="error_reporting" value="E_ALL"/>
+        <ini name="display_startup_errors" value="On"/>
+    </php>
 
     <logging>
         <log type="coverage-html" target="build/coverage/"/>

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -21,7 +21,7 @@ class ConfigManager implements IConfigurable
      * from argument $configFilePath
      *
      * @param string $configFilePath
-     * @return ConfigManager
+     * @return IConfigurable
      */
     public function __construct($configFilePath = null)
     {
@@ -33,7 +33,7 @@ class ConfigManager implements IConfigurable
      *
      * @param null|string $configFilePath
      *
-     * @return ConfigManager
+     * @return IConfigurable
      */
     public function loadConfig($configFilePath = null)
     {
@@ -54,7 +54,7 @@ class ConfigManager implements IConfigurable
      * @param null|string $configFilePath
      * @param bool $autoReloadConfig
      *
-     * @return ConfigManager
+     * @return IConfigurable
      * @throws RuntimeException
      */
     public function saveConfigFile($configFilePath = null, $autoReloadConfig = false)
@@ -149,7 +149,7 @@ class ConfigManager implements IConfigurable
      * @param string $configPath
      * @param mixed $newValue
      *
-     * @return ConfigManager
+     * @return IConfigurable
      */
     public function setValue($configPath, $newValue)
     {

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -9,7 +9,7 @@ use RuntimeException;
  * Class ConfigManager, class for easily read and access to php config array file.
  * @package clagiordano\weblibs\configmanager
  */
-class ConfigManager
+class ConfigManager implements IConfigurable
 {
     /** @var array $configData */
     private $configData = null;

--- a/src/IConfigurable.php
+++ b/src/IConfigurable.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace clagiordano\weblibs\configmanager;
+
+use RuntimeException;
+
+/**
+ * Class ConfigManager, class for easily read and access to php config array file.
+ * @package clagiordano\weblibs\configmanager
+ */
+interface IConfigurable
+{
+    /**
+     * Load config data from file and store it into internal property
+     *
+     * @param null|string $configFilePath
+     *
+     * @return ConfigManager
+     */
+    public function loadConfig($configFilePath = null);
+
+    /**
+     * Prepare and write config file on disk
+     *
+     * @param null|string $configFilePath
+     * @param bool $autoReloadConfig
+     *
+     * @return ConfigManager
+     * @throws RuntimeException
+     */
+    public function saveConfigFile($configFilePath = null, $autoReloadConfig = false);
+
+    /**
+     * Get value from config data throught keyValue path
+     *
+     * @param string $configPath
+     * @param mixed $defaultValue
+     *
+     * @return mixed
+     */
+    public function getValue($configPath, $defaultValue = null);
+
+    /**
+     * Check if exist required config for keyValue
+     *
+     * @param string $keyValue
+     *
+     * @return mixed
+     */
+    public function existValue($keyValue);
+
+    /**
+     * Set value in config path
+     *
+     * @param string $configPath
+     * @param mixed $newValue
+     *
+     * @return ConfigManager
+     */
+    public function setValue($configPath, $newValue);
+}

--- a/src/IConfigurable.php
+++ b/src/IConfigurable.php
@@ -15,7 +15,7 @@ interface IConfigurable
      *
      * @param null|string $configFilePath
      *
-     * @return ConfigManager
+     * @return IConfigurable
      */
     public function loadConfig($configFilePath = null);
 
@@ -25,7 +25,7 @@ interface IConfigurable
      * @param null|string $configFilePath
      * @param bool $autoReloadConfig
      *
-     * @return ConfigManager
+     * @return IConfigurable
      * @throws RuntimeException
      */
     public function saveConfigFile($configFilePath = null, $autoReloadConfig = false);
@@ -55,7 +55,7 @@ interface IConfigurable
      * @param string $configPath
      * @param mixed $newValue
      *
-     * @return ConfigManager
+     * @return IConfigurable
      */
     public function setValue($configPath, $newValue);
 }

--- a/tests/ConfigManagerTest.php
+++ b/tests/ConfigManagerTest.php
@@ -3,12 +3,13 @@
 namespace clagiordano\weblibs\configmanager\tests;
 
 use clagiordano\weblibs\configmanager\ConfigManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigManagerTest
  * @package clagiordano\weblibs\configmanager\tests
  */
-class ConfigManagerTest extends \PHPUnit_Framework_TestCase
+class ConfigManagerTest extends TestCase
 {
     /** @var ConfigManager $config */
     private $config = null;

--- a/tests/ConfigManagerTest.php
+++ b/tests/ConfigManagerTest.php
@@ -17,6 +17,8 @@ class ConfigManagerTest extends TestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         $this->config = new ConfigManager("TestConfigData.php");
         $this->assertInstanceOf('clagiordano\weblibs\configmanager\ConfigManager', $this->config);
 


### PR DESCRIPTION
This PR enforce the *current* `ConfigManager` interface dlaclaring a php interface and attaching it to the current `ConfigManager` without introducing any breaking changes. 

This PR also improve the composer scripts used to test and generate reports,
and allow github workflow build against multiple versions of PHP from 5.4 to 7.4  