### PR TITLE
Bump symfony/yaml from ^2.8 to ^2.8 || ^3.0 || ^4.0 || ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "symfony/yaml": "^2.8",
+        "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f98dd1d9d1b8f4986c6a54cc483c1166",
+    "content-hash": "5ae2a668088e704fc4d48f09d830189e",
     "packages": [
         {
             "name": "symfony/polyfill-ctype",
@@ -130,6 +130,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v2.8.52"
+            },
             "time": "2018-11-11T11:18:13+00:00"
         }
     ],
@@ -1709,5 +1712,5 @@
     "platform-overrides": {
         "php": "5.4"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Allows to install `clagiordano/weblibs-configmanager:^1.5` when `symfony/yaml:^5.0` is installed, now it is locked at 1.2.0.

`composer require clagiordano/weblibs-configmanager:^1.5 symfony/yaml:^5.0`

```
./composer.json has been updated
Running composer update clagiordano/weblibs-configmanager symfony/yaml
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires clagiordano/weblibs-configmanager ^1.5 -> satisfiable by clagiordano/weblibs-configmanager[v1.5.0].
    - clagiordano/weblibs-configmanager v1.5.0 requires symfony/yaml ^2.8 -> found symfony/yaml[v2.8.0, ..., v2.8.52] but it conflicts with your root composer.json require (^5.0).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```